### PR TITLE
Add Qualcomm 9207 (USB 1bbb:0196) modem support

### DIFF
--- a/modemdata/files/usr/share/modemdata/addon/usb/1bbb0196
+++ b/modemdata/files/usr/share/modemdata/addon/usb/1bbb0196
@@ -1,0 +1,244 @@
+# Qualcomm 9207 / USB 1bbb:0196
+
+lte_band_from_earfcn() {
+	case "$1" in
+		''|*[!0-9]*) return 0;;
+	esac
+
+	E="$1"
+	if [ "$E" -ge 0 ] && [ "$E" -le 599 ]; then
+		echo 1
+	elif [ "$E" -ge 600 ] && [ "$E" -le 1199 ]; then
+		echo 2
+	elif [ "$E" -ge 1200 ] && [ "$E" -le 1949 ]; then
+		echo 3
+	elif [ "$E" -ge 1950 ] && [ "$E" -le 2399 ]; then
+		echo 4
+	elif [ "$E" -ge 2400 ] && [ "$E" -le 2649 ]; then
+		echo 5
+	elif [ "$E" -ge 2750 ] && [ "$E" -le 3449 ]; then
+		echo 7
+	elif [ "$E" -ge 3450 ] && [ "$E" -le 3799 ]; then
+		echo 8
+	elif [ "$E" -ge 3800 ] && [ "$E" -le 4149 ]; then
+		echo 9
+	elif [ "$E" -ge 4150 ] && [ "$E" -le 4749 ]; then
+		echo 10
+	elif [ "$E" -ge 4750 ] && [ "$E" -le 4949 ]; then
+		echo 11
+	elif [ "$E" -ge 5010 ] && [ "$E" -le 5179 ]; then
+		echo 12
+	elif [ "$E" -ge 5180 ] && [ "$E" -le 5279 ]; then
+		echo 13
+	elif [ "$E" -ge 5280 ] && [ "$E" -le 5379 ]; then
+		echo 14
+	elif [ "$E" -ge 5730 ] && [ "$E" -le 5849 ]; then
+		echo 17
+	elif [ "$E" -ge 5850 ] && [ "$E" -le 5999 ]; then
+		echo 18
+	elif [ "$E" -ge 6000 ] && [ "$E" -le 6149 ]; then
+		echo 19
+	elif [ "$E" -ge 6150 ] && [ "$E" -le 6449 ]; then
+		echo 20
+	elif [ "$E" -ge 6450 ] && [ "$E" -le 6599 ]; then
+		echo 21
+	elif [ "$E" -ge 7700 ] && [ "$E" -le 8039 ]; then
+		echo 24
+	elif [ "$E" -ge 8040 ] && [ "$E" -le 8689 ]; then
+		echo 25
+	elif [ "$E" -ge 8690 ] && [ "$E" -le 9039 ]; then
+		echo 26
+	elif [ "$E" -ge 9210 ] && [ "$E" -le 9659 ]; then
+		echo 28
+	elif [ "$E" -ge 9660 ] && [ "$E" -le 9769 ]; then
+		echo 29
+	elif [ "$E" -ge 9770 ] && [ "$E" -le 9869 ]; then
+		echo 30
+	elif [ "$E" -ge 9870 ] && [ "$E" -le 9919 ]; then
+		echo 31
+	elif [ "$E" -ge 9920 ] && [ "$E" -le 10359 ]; then
+		echo 32
+	elif [ "$E" -ge 36000 ] && [ "$E" -le 36199 ]; then
+		echo 33
+	elif [ "$E" -ge 36200 ] && [ "$E" -le 36349 ]; then
+		echo 34
+	elif [ "$E" -ge 36350 ] && [ "$E" -le 36949 ]; then
+		echo 35
+	elif [ "$E" -ge 36950 ] && [ "$E" -le 37549 ]; then
+		echo 36
+	elif [ "$E" -ge 37550 ] && [ "$E" -le 37749 ]; then
+		echo 37
+	elif [ "$E" -ge 37750 ] && [ "$E" -le 38249 ]; then
+		echo 38
+	elif [ "$E" -ge 38250 ] && [ "$E" -le 38649 ]; then
+		echo 39
+	elif [ "$E" -ge 38650 ] && [ "$E" -le 39649 ]; then
+		echo 40
+	elif [ "$E" -ge 39650 ] && [ "$E" -le 41589 ]; then
+		echo 41
+	elif [ "$E" -ge 41590 ] && [ "$E" -le 43589 ]; then
+		echo 42
+	elif [ "$E" -ge 43590 ] && [ "$E" -le 45589 ]; then
+		echo 43
+	elif [ "$E" -ge 46790 ] && [ "$E" -le 54539 ]; then
+		echo 46
+	elif [ "$E" -ge 54540 ] && [ "$E" -le 55239 ]; then
+		echo 47
+	elif [ "$E" -ge 55240 ] && [ "$E" -le 56739 ]; then
+		echo 48
+	elif [ "$E" -ge 58240 ] && [ "$E" -le 59089 ]; then
+		echo 50
+	elif [ "$E" -ge 59090 ] && [ "$E" -le 59139 ]; then
+		echo 51
+	elif [ "$E" -ge 59140 ] && [ "$E" -le 60139 ]; then
+		echo 52
+	elif [ "$E" -ge 60140 ] && [ "$E" -le 60254 ]; then
+		echo 53
+	elif [ "$E" -ge 65536 ] && [ "$E" -le 66435 ]; then
+		echo 65
+	elif [ "$E" -ge 66436 ] && [ "$E" -le 67335 ]; then
+		echo 66
+	elif [ "$E" -ge 67336 ] && [ "$E" -le 67535 ]; then
+		echo 67
+	elif [ "$E" -ge 67536 ] && [ "$E" -le 67835 ]; then
+		echo 68
+	elif [ "$E" -ge 67836 ] && [ "$E" -le 68335 ]; then
+		echo 69
+	elif [ "$E" -ge 68336 ] && [ "$E" -le 68585 ]; then
+		echo 70
+	elif [ "$E" -ge 68586 ] && [ "$E" -le 68935 ]; then
+		echo 71
+	elif [ "$E" -ge 69036 ] && [ "$E" -le 69465 ]; then
+		echo 74
+	elif [ "$E" -ge 69466 ] && [ "$E" -le 70315 ]; then
+		echo 75
+	elif [ "$E" -ge 70316 ] && [ "$E" -le 70365 ]; then
+		echo 76
+	elif [ "$E" -ge 70366 ] && [ "$E" -le 70545 ]; then
+		echo 85
+	elif [ "$E" -ge 70546 ] && [ "$E" -le 70595 ]; then
+		echo 87
+	elif [ "$E" -ge 70596 ] && [ "$E" -le 70645 ]; then
+		echo 88
+	elif [ "$E" -ge 70646 ] && [ "$E" -le 70655 ]; then
+		echo 103
+	elif [ "$E" -ge 70656 ] && [ "$E" -le 70705 ]; then
+		echo 104
+	elif [ "$E" -ge 70706 ] && [ "$E" -le 71055 ]; then
+		echo 106
+	fi
+}
+
+parse_qc_cell_metrics() {
+	echo "$1" | awk -v prefix="$2" '
+		/^\$QCRSR[PQ][[:space:]]*:/ {
+			sub(/^\$QCRSR[PQ][[:space:]]*:[[:space:]]*/, "", $0)
+			n = split($0, a, ",")
+			idx = 0
+			for (i = 1; i + 2 <= n; i += 3) {
+				idx++
+				v1 = a[i]
+				v2 = a[i + 1]
+				v3 = a[i + 2]
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "", v1)
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "", v2)
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "", v3)
+				gsub(/"/, "", v3)
+				printf "%s_%d_A=\"%s\";%s_%d_B=\"%s\";%s_%d_C=\"%s\";", prefix, idx, v1, prefix, idx, v2, prefix, idx, v3
+			}
+			printf "%s_COUNT=\"%d\";\n", prefix, idx
+		}
+	'
+}
+
+if [ "$REGOK" = "1" ]; then
+	O=$(sms_tool -d "$DEVICE" at 'AT+CEREG=2;+CEREG?' 2>/dev/null | tr -d '\r')
+	T=$(echo "$O" | awk -F'"' '/^\+CEREG:/ {print $2; exit}' | tr '[:lower:]' '[:upper:]' | xargs)
+	if [ -n "$T" ]; then
+		T_HEX="$T"
+		T_DEC=$(printf '%d\n' 0x"$T" 2>/dev/null)
+		LAC_HEX="$T"
+		LAC_DEC="$T_DEC"
+		addon 23 "TAC" "${T_DEC} (${T})"
+	fi
+
+	T=$(echo "$O" | awk -F'"' '/^\+CEREG:/ {print $6; exit}' | tr '[:lower:]' '[:upper:]' | xargs)
+	[ -z "$T" ] && T=$(echo "$O" | awk -F'"' '/^\+CEREG:/ {print $4; exit}' | tr '[:lower:]' '[:upper:]' | xargs)
+	if [ -n "$T" ]; then
+		CID_HEX="$T"
+		CID_DEC=$(printf '%d\n' 0x"$T" 2>/dev/null)
+	fi
+
+	O=$(sms_tool -d "$DEVICE" at 'AT$QCRSRP?' 2>/dev/null | tr -d '\r')
+	eval "$(parse_qc_cell_metrics "$O" "QCRSRP")"
+	eval "$(parse_qc_cell_metrics "$(sms_tool -d "$DEVICE" at 'AT$QCRSRQ?' 2>/dev/null | tr -d '\r')" "QCRSRQ")"
+
+	T="$QCRSRP_1_A"
+	[ -n "$T" ] && addon 33 "PCI" "$T"
+
+	T="$QCRSRP_1_B"
+	PBAND=""
+	if [ -n "$T" ]; then
+		BAND=$(lte_band_from_earfcn "$T")
+		[ -n "$BAND" ] && PBAND="$(band4g "$BAND")"
+		[ -n "$PBAND" ] && addon 30 "Primary band" "$PBAND"
+		addon 34 "EARFCN" "$T"
+	fi
+
+	T="$QCRSRP_1_C"
+	[ -n "$T" ] && addon 36 "RSRP" "$T dBm"
+
+	T="$QCRSRQ_1_C"
+	[ -n "$T" ] && addon 37 "RSRQ" "$T dB"
+
+	O=$(sms_tool -d "$DEVICE" at 'AT+CSQ' 2>/dev/null | tr -d '\r')
+	T=$(echo "$O" | sed -n 's/^+CSQ:[[:space:]]*\([0-9][0-9]*\),.*/\1/p' | head -n 1 | xargs)
+	if [ -n "$T" ] && [ "$T" -ge 0 ] && [ "$T" -le 31 ]; then
+		addon 35 "RSSI" "$((-113 + 2 * T)) dBm"
+	fi
+
+	O=$(sms_tool -d "$DEVICE" at 'AT$QCSQ' 2>/dev/null | tr -d '\r')
+	T=$(echo "$O" | sed -n 's/^\$QCSQ[[:space:]]*:[[:space:]]*[^,]*,[^,]*,\([^,]*\),\([^,]*\),.*/\1,\2/p' | head -n 1 | xargs)
+	if [ -n "$T" ]; then
+		QSIR=${T%,*}
+		QPATH=${T#*,}
+		case "$QSIR:$QPATH" in
+			*[!0-9:-]*)
+				;;
+			*)
+				if [ "$QSIR" -ge -10 ] && [ "$QSIR" -le 20 ] && [ "$QPATH" -ge 46 ] && [ "$QPATH" -le 148 ]; then
+					addon 38 "SINR" "$QSIR dB"
+				fi
+				;;
+		esac
+	fi
+
+	SCC_IDX=0
+	I=2
+	while [ "${QCRSRP_COUNT:-0}" -gt 1 ] && [ "$I" -le "$QCRSRP_COUNT" ] && [ "$SCC_IDX" -lt 4 ]; do
+		eval "TPCI=\${QCRSRP_${I}_A}"
+		eval "TEARFCN=\${QCRSRP_${I}_B}"
+		eval "TRSRP=\${QCRSRP_${I}_C}"
+		eval "TRSRQ=\${QCRSRQ_${I}_C}"
+		if [ -n "$TPCI" ] && [ -n "$TEARFCN" ] && [ "$TPCI" = "$QCRSRP_1_A" ] && [ "$TEARFCN" != "$QCRSRP_1_B" ]; then
+			SCC_IDX=$((SCC_IDX + 1))
+			POS=$(((SCC_IDX + 4) * 10))
+			BAND=$(lte_band_from_earfcn "$TEARFCN")
+			TBAND=""
+			[ -n "$BAND" ] && TBAND="$(band4g "$BAND")"
+			[ -n "$TBAND" ] && addon "$POS" "(S${SCC_IDX}) band" "$TBAND"
+			addon $((POS + 3)) "(S${SCC_IDX}) PCI" "$TPCI"
+			addon $((POS + 4)) "(S${SCC_IDX}) EARFCN" "$TEARFCN"
+			[ -n "$TRSRP" ] && addon $((POS + 6)) "(S${SCC_IDX}) RSRP" "$TRSRP dBm"
+			[ -n "$TRSRQ" ] && addon $((POS + 7)) "(S${SCC_IDX}) RSRQ" "$TRSRQ dB"
+			[ -n "$TBAND" ] && MODE_BANDS="${MODE_BANDS} / ${TBAND}"
+		fi
+		I=$((I + 1))
+	done
+
+	if [ "$SCC_IDX" -gt 0 ]; then
+		[ -n "$PBAND" ] && MODE="LTE-A ${PBAND}${MODE_BANDS}"
+	else
+		[ -n "$PBAND" ] && MODE="LTE ${PBAND}"
+	fi
+fi

--- a/modemdata/files/usr/share/modemdata/vendorproduct/usb/1bbb0196
+++ b/modemdata/files/usr/share/modemdata/vendorproduct/usb/1bbb0196
@@ -1,0 +1,45 @@
+# Qualcomm 9207 / USB 1bbb:0196
+
+VENDOR="Qualcomm"
+PRODUCT="Qualcomm 9207 LTE modem (4108)"
+
+O=$(sms_tool -d "$DEVICE" at 'AT+GMI' 2>/dev/null | tr -d '\r')
+T=$(echo "$O" | sed -n '2p' | xargs)
+[ -z "$T" ] && T=$(echo "$O" | awk '/^\+GMI:/{sub(/^\+GMI:[[:space:]]*/, ""); print; exit}' | xargs)
+case "$T" in
+	''|'QUALCOMM INCORPORATED'|'Qualcomm Incorporated')
+		;;
+	*)
+		VENDOR="$T"
+		;;
+esac
+
+O=$(sms_tool -d "$DEVICE" at 'AT+GMM' 2>/dev/null | tr -d '\r')
+T=$(echo "$O" | sed -n '2p' | xargs)
+[ -z "$T" ] && T=$(echo "$O" | awk '/^\+GMM:/{sub(/^\+GMM:[[:space:]]*/, ""); print; exit}' | xargs)
+case "$T" in
+	''|'4108')
+		;;
+	*)
+		PRODUCT="$T"
+		;;
+esac
+
+O=$(sms_tool -d "$DEVICE" at 'AT+GMR' 2>/dev/null | tr -d '\r')
+T=$(echo "$O" | sed -n '2p' | xargs)
+[ -z "$T" ] && T=$(echo "$O" | awk '/^\+GMR:/{sub(/^\+GMR:[[:space:]]*/, ""); print; exit}' | xargs)
+[ -n "$T" ] && REVISION="$T"
+
+O=$(sms_tool -d "$DEVICE" at 'AT+GSN' 2>/dev/null | tr -d '\r')
+T=$(echo "$O" | sed -n '2p' | xargs)
+[ -z "$T" ] && T=$(echo "$O" | sed -n 's/^\([0-9][0-9]*\)$/\1/p' | head -n 1 | xargs)
+[ -n "$T" ] && IMEI="$T"
+
+O=$(sms_tool -d "$DEVICE" at 'AT+ICCID' 2>/dev/null | tr -d '\r')
+T=$(echo "$O" | sed -n 's/^ICCID:[[:space:]]*\(.*\)$/\1/p' | head -n 1 | xargs)
+[ -n "$T" ] && ICCID="$T"
+
+O=$(sms_tool -d "$DEVICE" at 'AT+CIMI' 2>/dev/null | tr -d '\r')
+T=$(echo "$O" | sed -n '2p' | xargs)
+[ -z "$T" ] && T=$(echo "$O" | sed -n 's/^\([0-9][0-9]*\)$/\1/p' | head -n 1 | xargs)
+[ -n "$T" ] && IMSI="$T"


### PR DESCRIPTION
This PR adds support for Qualcomm 9207 devices exposed as USB ID `1bbb:0196`.

  Changes:
  - add vendor/product detection for Qualcomm 9207 (4108)
  - add serial-mode signal parsing via `AT$QCRSRP?`, `AT$QCRSRQ?`, `AT$QCSQ`, `AT+CEREG?` and `AT+CSQ`
  - expose LTE/LTE-A primary and secondary carrier details

  Tested on a HH41V router with a Qualcomm 9207 LTE modem. The modem was verified locally through `product.sh`,
  `params.sh` and `md_serial_ecm`, including TAC/CID, PCI, EARFCN, RSRP/RSRQ/RSSI and CA secondary carrier
  reporting.
