### PR TITLE
Add support for Fibocom FG621-EA (in NCM mode)

### DIFF
--- a/modemdata/files/usr/share/modemdata/addon/usb/2cb70a05
+++ b/modemdata/files/usr/share/modemdata/addon/usb/2cb70a05
@@ -1,0 +1,123 @@
+# Fibocom FG621-EA
+# Based on 0e8d7126
+
+bandwidth4g() {
+	T=""
+	case $1 in
+		6) T="1.4 MHz";;
+		15) T="3 MHz";;
+		25) T="5 MHz";;
+		50) T="10 MHz";;
+		75) T="15 MHz";;
+		100) T="20 MHz";;
+	esac
+	echo "$T"
+}
+
+O=$(sms_tool -d $DEVICE at "AT+MTSM=1")
+
+T=$(echo "$O" | awk -F'[: ]+' '/\+MTSM/{printf "%.1f", $2}' | xargs)
+
+[ -n "$T" ] && addon 10 "Temperature" "$T &deg;C"
+
+if [ "$REGOK" = "1" ]; then
+
+O=$(sms_tool -d $DEVICE at "AT+GTCCINFO?;+GTCAINFO?")
+
+if [ "x$MODE_NUM" = "x7" ] || [ "x$MODE_NUM" = "x16" ]; then
+	MODE="LTE"
+	if [ "x$MODE_NUM" = "x7" ]; then
+		LINE=$(echo "$O" | grep -A 10 "^+GTCCINFO:" | grep '^1,9')
+		[ -n "$LINE" ] && MODE_NUM=16
+	fi
+
+	LINE=$(echo "$O" | grep -A 10 "^+GTCCINFO:" | grep '^1,4,'$((COPS_MCC * 1))','$((COPS_MNC * 1))'')
+	[ -z "$LINE" ] && LINE=$(echo "$O" | grep -A 10 "^+GTCCINFO:" | grep '^1,4,'$((COPS_MCC * 1))',')
+
+	T=$(echo "$LINE" | awk -F, '{print $5}')
+	if [ -n "$T" ]; then
+		T_DEC=$(printf "%d" "0x$T")
+		addon 23 "TAC" "${T_DEC} ($T)"
+	fi
+
+	T=$(echo "$LINE" | awk -F, '{print $10}')
+	if [ -n "$T" ]; then
+		T1=$(bandwidth4g "$T")
+		[ -n "$T1" ] && addon 32 "Bandwidth DL" "$T1"
+	fi
+	T=$(echo "$LINE" | awk -F, '{print $11}')
+	[ -n "$T" ] && addon 38 "SINR" "$(echo "$T" | awk '{printf "%0.1f", $1/2}') dB"
+	T=$(echo "$LINE" | awk -F, '{print $13}')
+	[ -n "$T" ] && addon 36 "RSRP" "$(echo "$T" | awk '{printf "%0.1f", $1 - 141}') dBm"
+	T=$(echo "$LINE" | awk -F, '{print $14}' | xargs)
+	[ -n "$T" ] && addon 37 "RSRQ" "$(echo "$T" | awk '{printf "%0.1f", $1/2 - 20}') dB"
+
+	LINE=$(echo "$O" | grep -A 10 "^+GTCAINFO:" | grep '^PCC:')
+	if [ -n "$LINE" ]; then
+		T=$(echo "$LINE" | awk -F[:,] '{print $2}')		# primary band from PCC (band + 100)
+		if [ -n "$T" ]; then
+			B=$(band4g $((T - 100)))
+			addon 30 "Primary band" "$B"
+			MODE="LTE $B"
+		fi
+		T=$(echo "$LINE" | awk -F[:,] '{print $3}')		# PCI
+		[ -n "$T" ] && addon 33 "PCI" "$T"
+		T=$(echo "$LINE" | awk -F[:,] '{print $4}')		# EARFCN
+		[ -n "$T" ] && addon 34 "EARFCN" "$T"
+		T=$(echo "$LINE" | awk -F[:,] '{if($2 < 500){print $6}}')
+		if [ -n "$T" ] && [ "$T" != "255" ] ; then
+			T1=$(bandwidth4g "$T")
+			[ -n "$T1" ] && addon 31 "Bandwidth UL" "$T1"
+		fi
+	fi
+	
+	if [ "$CSQ" -ge 0 ] && [ "$CSQ" -le 31 ]; then		# RSSI retrieved by params.sh with AT+CSQ;
+		RSSI=$(( -113 + (CSQ * 2) ))
+		addon 35 "RSSI" "${RSSI} dBm"
+	fi
+
+	LINES=$(echo "$O" | grep -A 10 "^+GTCAINFO:" | grep '^SCC\s*[0-9]:2')
+	echo "$LINES" | grep -q "^SCC" && MODE="${MODE/LTE/LTE-A}"
+IFS="
+"
+	IDX=1
+	for LINE in $LINES; do
+		POS=$(((IDX + 4) * 10))
+		UL=$(echo "$LINE" | awk -F[:,] '{print $3}')
+		T=$(echo "$LINE" | awk -F[:,] '{print $4}')
+		if [ -n "$T" ]; then
+			B=$(band4g $((T - 100)))
+			addon $POS "(S${IDX}) band" "$B"
+			MODE="$MODE / $B"
+			[ "x$UL" = "x1" ] && addon 150 "(UL S) band" "$B"
+		fi
+		T=$(echo "$LINE" | awk -F[:,] '{print $5}')
+		[ -n "$T" ] && addon $((POS + 3)) "(S${IDX}) PCI" "$T"
+		T=$(echo "$LINE" | awk -F[:,] '{print $6}')
+		[ -n "$T" ] && addon $((POS + 4)) "(S${IDX}) EARFCN" "$T"
+		T=$(echo "$LINE" | awk -F[:,] '{print $7}')
+		if [ -n "$T" ] && [ "$T" != "255" ]; then
+			T1=$(bandwidth4g "$T")
+			[ -n "$T1" ] && addon $((POS + 2)) "(S${IDX}) Bandwidth DL" "$T1"
+		fi
+		T=$(echo "$LINE" | awk -F[:,] '{print $8}')
+		if [ -n "$T" ] && [ "$T" != "255" ] && [ "x$UL" = "x1" ]; then
+			T1=$(bandwidth4g "$T")
+			[ -n "$T1" ] && addon 152 "(UL S) Bandwidth UL" "$T1"
+		fi
+
+		T=$(echo "$LINE" | awk -F[:,] '{print $9}')
+		[ -n "$T" ] && addon $((POS + 6)) "(S${IDX}) RSRP" "$(echo "$T" | awk '{printf "%0.1f", $1 - 141}') dBm"
+
+		T=$(echo "$LINE" | awk -F[:,] '{print $10}')
+		[ -n "$T" ] && addon $((POS + 7)) "(S${IDX}) RSRQ" "$(echo "$T" | awk '{printf "%0.1f", $1/2 - 20}') dB"
+
+		T=$(echo "$LINE" | awk -F[:,] '{print $11}')
+		[ -n "$T" ] && addon $((POS + 8)) "(S${IDX}) SINR" "$(echo "$T" | awk '{printf "%0.1f", $1/2}') dB"
+
+		IDX=$((IDX + 1))
+	done
+
+fi
+
+fi

--- a/modemdata/files/usr/share/modemdata/params.sh
+++ b/modemdata/files/usr/share/modemdata/params.sh
@@ -163,7 +163,7 @@ FORCE_PLMN=$2
 
 RES="/usr/share/modemdata"
 
-O=$(sms_tool -D -d $DEVICE at "AT+CPIN?;+CSQ;+COPS=3,0;+COPS?;+COPS=3,2;+COPS?;+CREG=2;+CREG?" | tr -d '\r')
+O=$(sms_tool -D -d $DEVICE at "AT+CSQ;+COPS=3,0;+COPS?;+COPS=3,2;+COPS?;+CREG=2;+CREG?;+CPIN?" | tr -d '\r')
 
 # CSQ
 CSQ=$(echo "$O" | awk -F[,\ ] '/^\+(csq|CSQ)/ {print $2}')


### PR DESCRIPTION
Adds support for Fibocom FG621-EA (in NCM mode), used in:
- TP-Link TL-MR500v1
- Asus 4G-AX56

The data parsing was adapted from the existing `0e8d7126` script, however as mentioned in [#139](https://github.com/4IceG/luci-app-3ginfo-lite/pull/139) the Fibocom FG621 is quirky (read broken) on how it handles `AT+CPIN?` as part of a complex AT query and the only workaround I found was to move the CPIN command at the end of the queries list. I hope this an acceptable solution and doesn't break other modems.

I've been testing the router/modem with these changes on OpenWrt 25.12.2 for 3 weeks and it didn't crash (yet...).

<img width="1415" height="894" alt="Screenshot 2026-04-27 at 17-40-43 TL-MR500v1 Modem(s) redacted" src="https://github.com/user-attachments/assets/e3af6b3b-6fe5-42b4-b6b5-f1ec5d473300" />
